### PR TITLE
Add Sign In page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,8 @@
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import { ThemeProvider, CssBaseline } from '@mui/material';
 import { createTheme } from '@mui/material/styles';
+import SignIn from './pages/SignIn';
+import SignUp from './pages/SignUp';
 
 // Create a theme instance
 const theme = createTheme({
@@ -21,7 +23,8 @@ function App() {
       <CssBaseline />
       <Router>
         <Routes>
-          <Route path="/" element={<div>Welcome to Codex Journal</div>} />
+          <Route path="/" element={<SignIn />} />
+          <Route path="/signup" element={<SignUp />} />
         </Routes>
       </Router>
     </ThemeProvider>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,5 +1,6 @@
+@import url("https://fonts.googleapis.com/css2?family=Lato:wght@400;700&display=swap");
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
+  font-family: "Lato", Arial, sans-serif;
   line-height: 1.5;
   font-weight: 400;
 

--- a/frontend/src/pages/SignIn.tsx
+++ b/frontend/src/pages/SignIn.tsx
@@ -1,0 +1,66 @@
+import { useState } from 'react';
+import { Box, Button, Link, Stack, TextField, Typography } from '@mui/material';
+
+function SignIn() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    // Placeholder submit handler
+    console.log('Signing in with', { email, password });
+  };
+
+  return (
+    <Box
+      component="form"
+      onSubmit={handleSubmit}
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        height: '100vh',
+        fontFamily: 'Lato, sans-serif',
+      }}
+    >
+      <Stack spacing={2} width={300}>
+        <Typography variant="h5" textAlign="center">
+          Sign In
+        </Typography>
+        <TextField
+          label="Email"
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          inputProps={{ style: { fontFamily: 'Lato, sans-serif', fontSize: 16 } }}
+        />
+        <TextField
+          label="Password"
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          inputProps={{ style: { fontFamily: 'Lato, sans-serif', fontSize: 16 } }}
+        />
+        <Button
+          type="submit"
+          variant="contained"
+          sx={{
+            backgroundColor: '#800020',
+            '&:hover': { backgroundColor: '#800020' },
+            fontWeight: 'bold',
+            fontFamily: 'Lato, sans-serif',
+            fontSize: 16,
+          }}
+        >
+          Sign In
+        </Button>
+        <Link href="/signup" underline="hover" sx={{ color: '#800020', textAlign: 'center', fontFamily: 'Lato, sans-serif', fontSize: 16 }}>
+          Sign Up
+        </Link>
+      </Stack>
+    </Box>
+  );
+}
+
+export default SignIn;

--- a/frontend/src/pages/SignUp.tsx
+++ b/frontend/src/pages/SignUp.tsx
@@ -1,0 +1,19 @@
+import { Box, Typography } from '@mui/material';
+
+function SignUp() {
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        height: '100vh',
+        fontFamily: 'Lato, sans-serif',
+      }}
+    >
+      <Typography variant="h5">Sign Up Page</Typography>
+    </Box>
+  );
+}
+
+export default SignUp;


### PR DESCRIPTION
## Summary
- create SignIn and SignUp pages
- add Lato font to global styles
- route `/` to SignIn and `/signup` to SignUp

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684067fe0e748330824bd158217c1cbd