### PR TITLE
Provide env file example and DB fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+MONGODB_URI=mongodb+srv://kwabspam:<db_password>@cluster0.bgysj92.mongodb.net/?retryWrites=true&w=majority&appName=Cluster0
+PORT=5001

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 node_modules
+
+# Environment variables
+.env

--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# Codex Journal
+
+## Setup
+
+1. Copy `.env.example` to `.env` in the project root and fill in your MongoDB connection string.
+2. Install dependencies:
+   ```bash
+   npm run install:all
+   ```
+3. Start the development servers:
+   ```bash
+   npm start
+   ```
+
+The backend will connect to the URI defined in `MONGODB_URI`. If that variable is not set, it will fall back to a local MongoDB instance at `mongodb://localhost:27017/codex-journal`.

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -14,11 +14,7 @@ app.use(cors());
 app.use(express.json());
 
 // Database connection
-const mongoURI = process.env.MONGODB_URI;
-if (!mongoURI) {
-  console.error('MONGODB_URI is not defined in environment variables');
-  process.exit(1);
-}
+const mongoURI = process.env.MONGODB_URI || 'mongodb://localhost:27017/codex-journal';
 
 mongoose.connect(mongoURI)
   .then(() => console.log('Connected to MongoDB'))


### PR DESCRIPTION
## Summary
- ignore `.env`
- provide `.env.example`
- document setup in `README.md`
- fall back to local MongoDB URL when `MONGODB_URI` is not provided

## Testing
- `npm test --workspace=backend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684079234540833082a737d1cd9c680d